### PR TITLE
A cleaner autotools implementation of the gzip reading code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,37 @@ if test x$ac_cv_header_Eigen_Dense = xno; then
 fi
 
 
+# See if we can use the Boost IOstreams libraries for reading gzipped
+# files
+AC_ARG_WITH([boost-iostreams],
+ AS_HELP_STRING([--with-boost-iostreams], [Use the Boost Iostreams library to
+ allow reading from gzipped files. This is enabled by default]
+               )
+)
+
+if test "x$with_boost_iostreams" != "xno"; then
+    AC_MSG_NOTICE([building using the Boost IOstreams library enabled])
+
+    AC_ARG_WITH([boost-include-path],
+        [AS_HELP_STRING([--with-boost-include-path],
+          [location of the Boost headers, defaults to /usr/include/boost])],
+        [CPPFLAGS+=" -I${withval}"],
+        [CPPFLAGS+=' -I/usr/include/'])
+
+    # Check for the Boost IOstreams header files
+    AC_CHECK_HEADER([boost/iostreams/filter/gzip.hpp],
+        [],
+        [AC_MSG_ERROR([Could not find the Boost IOstreams header files. Did \
+you specify --with-boost-include-path correctly? Or use --without-boost \
+to disable the reading of gzipped files.])]
+    )
+else
+   AC_MSG_NOTICE([not using the Boost IOstreams libraries, so input \
+from gzipped files is not possible])
+fi
+AM_CONDITIONAL([WITH_BOOST_IOSTREAMS], test "x$with_boost_iostreams" != "xno")
+
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL
 AC_C_INLINE

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,8 +37,6 @@ RHEADERS = include/R.h include/Rmath.h include/R_ext/Arith.h		\
  include/R_ext/Print.h include/R_ext/Random.h include/R_ext/Utils.h	\
  include/R_ext/RS.h
 
-LDADD = -lboost_iostreams -lz 
-
 bin_PROGRAMS =
 if BUILD_palinear
 bin_PROGRAMS += palinear
@@ -62,10 +60,12 @@ endif
 
 palinear_SOURCES = $(REGFILES) $(FVSRC) $(FVHEADERS)
 palinear_CPPFLAGS = -DLINEAR $(AM_CPPFLAGS)
+palinear_LDADD =
 palinear_SOURCES += $(EIGENFILES)
 
 palogist_SOURCES = $(REGFILES) $(FVSRC) $(FVHEADERS)
 palogist_CPPFLAGS = -DLOGISTIC $(AM_CPPFLAGS)
+palogist_LDADD =
 palogist_SOURCES += $(EIGENFILES)
 
 pacoxph_SOURCES = $(COXSRC) $(REGFILES) $(FVSRC) $(FVHEADERS)	\
@@ -73,7 +73,18 @@ pacoxph_SOURCES = $(COXSRC) $(REGFILES) $(FVSRC) $(FVHEADERS)	\
 pacoxph_CXXFLAGS = -I $(top_srcdir)/src/include $(AM_CXXFLAGS)
 pacoxph_CPPFLAGS = -DCOXPH $(AM_CPPFLAGS)
 pacoxph_CFLAGS = -I $(top_srcdir)/src/include $(AM_CFLAGS)
+pacoxph_LDADD =
 pacoxph_SOURCES += $(EIGENFILES)
+
+if WITH_BOOST_IOSTREAMS
+palinear_CPPFLAGS += -DWITH_BOOST_IOSTREAMS
+palinear_LDADD += -lboost_iostreams -lz
+palogist_CPPFLAGS += -DWITH_BOOST_IOSTREAMS
+palogist_LDADD += -lboost_iostreams -lz
+pacoxph_CPPFLAGS += -DWITH_BOOST_IOSTREAMS
+pacoxph_LDADD += -lboost_iostreams -lz
+endif
+
 
 extract_snp_SOURCES = extract-snp.cpp $(FVSRC) $(FVHEADERS)
 

--- a/src/gendata.cpp
+++ b/src/gendata.cpp
@@ -36,9 +36,11 @@
 #include "utilities.h"
 #include <iostream>
 #include <fstream>
+
+#if WITH_BOOST_IOSTREAMS
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
-
+#endif
 
 void gendata::mldose_line_to_matrix(const int k,
                                     const char *all_numbers,
@@ -251,9 +253,15 @@ void gendata::re_gendata(const char * fname,
 
     G.reinit(nids, (nsnps * ngpreds));
 
+#if WITH_BOOST_IOSTREAMS
     std::ifstream file(fname, std::ios_base::in | std::ios_base::binary);
     boost::iostreams::filtering_istream infile;
     std::string filename = fname;
+    // Note: a better check would be to read the first two bytes of
+    // the file and check for the gzip signature: 0x1f8b
+    // W.r.t. endianness and bytt width: compare each byte separately,
+    // see the comment to this SE answer:
+    // http://stackoverflow.com/a/6059342/881084
     if (filename.compare(filename.length() - 2, 2, "gz") == 0)
     {
         infile.push(boost::iostreams::gzip_decompressor());
@@ -263,8 +271,16 @@ void gendata::re_gendata(const char * fname,
         std::cout << "no gziped:" << ":\n";
     }
     infile.push(file);
+#else
+    std::ifstream infile;
+    infile.open(fname);
+#endif
 
+#if WITH_BOOST_IOSTREAMS
     if (!file)
+#else
+    if (!infile)
+#endif
     {
         std::cerr << "gendata: cannot open file " << fname << endl;
         exit(1);
@@ -297,7 +313,11 @@ void gendata::re_gendata(const char * fname,
                     cerr << "phenotype file and dose or probability file "
                             << "did not match at line " << i + 2 << " ("
                             << tmpid << " != " << idnames[k] << ")" << endl;
+#if WITH_BOOST_IOSTREAMS
                     file.close();
+#else
+                    infile.close();
+#endif
                     exit(1);
                 }
             }
@@ -327,7 +347,11 @@ void gendata::re_gendata(const char * fname,
         }
     }
 
+#if WITH_BOOST_IOSTREAMS
     file.close();
+#else
+    infile.close();
+#endif
 }
 
 // HERE NEED A NEW CONSTRUCTOR BASED ON DATABELBASECPP OBJECT

--- a/src/gendata.cpp
+++ b/src/gendata.cpp
@@ -251,13 +251,16 @@ void gendata::re_gendata(const char * fname,
 
     G.reinit(nids, (nsnps * ngpreds));
 
-	std::ifstream file(fname, std::ios_base::in | std::ios_base::binary);
-	boost::iostreams::filtering_istream infile;
-	std::string filename=fname;
-    if (filename.compare(filename.length()-2,2,"gz")== 0){
-    	infile.push(boost::iostreams::gzip_decompressor());
-    }else{
-    	std::cout << "no gziped:"<< ":\n";
+    std::ifstream file(fname, std::ios_base::in | std::ios_base::binary);
+    boost::iostreams::filtering_istream infile;
+    std::string filename = fname;
+    if (filename.compare(filename.length() - 2, 2, "gz") == 0)
+    {
+        infile.push(boost::iostreams::gzip_decompressor());
+    }
+    else
+    {
+        std::cout << "no gziped:" << ":\n";
     }
     infile.push(file);
 

--- a/src/usage.cpp
+++ b/src/usage.cpp
@@ -31,6 +31,10 @@
 #include "config.h"
 #endif
 
+#if WITH_BOOST_IOSTREAMS
+#include <boost/version.hpp>
+#endif
+
 #include "eigen_mematrix.h"
 
 
@@ -103,6 +107,10 @@ void print_version(void) {
     cout << "Using EIGEN version " << EIGEN_WORLD_VERSION
          << "." << EIGEN_MAJOR_VERSION << "." << EIGEN_MINOR_VERSION
          << " for matrix operations\n";
+#if WITH_BOOST_IOSTREAMS
+    cout << "Using Boost libraries version " << BOOST_LIB_VERSION << endl;
+#endif
+
 }
 
 


### PR DESCRIPTION
Hi Maarten,

I used some code from the `ProbABEL-pvals` branch to add a few ./configure options that check for the required Boost library. This PR also keeps the option open of not using the Boost lib (and then live without the ability to read gzipped data). 
